### PR TITLE
feat(store): add option outsideZone in root store dispatch

### DIFF
--- a/packages/store/src/components/ng-redux.ts
+++ b/packages/store/src/components/ng-redux.ts
@@ -52,7 +52,10 @@ export abstract class NgRedux<RootState> implements ObservableStore<RootState> {
   abstract provideStore: (store: Store<RootState>) => void;
 
   // Redux Store methods
-  abstract dispatch: Dispatch<AnyAction>;
+  abstract dispatch: <A extends AnyAction>(
+    action: A,
+    outsideZone?: boolean,
+  ) => A;
   abstract getState: () => RootState;
   abstract subscribe: (listener: () => void) => Unsubscribe;
   abstract replaceReducer: (nextReducer: Reducer<RootState, AnyAction>) => void;

--- a/packages/store/src/components/root-store.ts
+++ b/packages/store/src/components/root-store.ts
@@ -73,7 +73,10 @@ export class RootStore<RootState> extends NgRedux<RootState> {
     this.store!.replaceReducer(nextReducer);
   };
 
-  dispatch: Dispatch<AnyAction> = <A extends AnyAction>(action: A): A => {
+  dispatch: Dispatch<AnyAction> = <A extends AnyAction>(
+    action: A,
+    outsideZone: boolean = false,
+  ): A => {
     assert(
       !!this.store,
       'Dispatch failed: did you forget to configure your store? ' +
@@ -81,7 +84,7 @@ export class RootStore<RootState> extends NgRedux<RootState> {
         'README.md#quick-start',
     );
 
-    if (!NgZone.isInAngularZone()) {
+    if (!NgZone.isInAngularZone() && !outsideZone) {
       return this.ngZone.run(() => this.store!.dispatch(action));
     } else {
       return this.store!.dispatch(action);


### PR DESCRIPTION
This PR adds an option outsideZone in root store dispatch in order to manually control zone.run with Angular.